### PR TITLE
Integrate needle tokens and style the editor 🪡

### DIFF
--- a/demos/demo-base/css/app.css
+++ b/demos/demo-base/css/app.css
@@ -27,7 +27,6 @@ a:hover {
 body {
     margin: 0;
     display: flex;
-    min-width: 320px;
     min-height: 100vh;
     width: 100%;
     min-width: 100%;
@@ -147,10 +146,19 @@ body {
 }
 
 .database-editor {
+    border-radius: var(--border-radius-3xl);
+    overflow: hidden;
     display: flex;
     width: calc(100% - 16px);
     min-width: calc(100% - 16px);
     max-width: calc(100% - 16px);
+    border: 2px solid rgb(var(--colors-neutral-50));
+}
+
+@media (prefers-color-scheme: dark) {
+    .database-editor {
+        border: 2px solid rgb(var(--colors-primary-10));
+    }
 }
 
 .info {

--- a/demos/demo-base/src/index.js
+++ b/demos/demo-base/src/index.js
@@ -75,24 +75,24 @@ SET variable.propKey = 1;`,
   }
 };
 
-export const metaQuery = `	CALL db.labels() YIELD label
-	RETURN {name:'labels', data:COLLECT(label)[..1000]} AS result
-	UNION ALL
-	CALL db.relationshipTypes() YIELD relationshipType
-	RETURN {name:'relationshipTypes', data:COLLECT(relationshipType)[..1000]} AS result
-	UNION ALL
-	CALL db.propertyKeys() YIELD propertyKey
-	RETURN {name:'propertyKeys', data:COLLECT(propertyKey)[..1000]} AS result
-	UNION ALL
-	CALL dbms.functions() YIELD name, signature, description
-	RETURN {name:'functions', data: collect({name: name, signature: signature, description: description})} AS result
-	UNION ALL
-	CALL dbms.procedures() YIELD name, signature, description
-	RETURN {name:'procedures', data:collect({name: name, signature: signature, description: description})} AS result
-	UNION ALL
-	MATCH () RETURN { name:'nodes', data:count(*) } AS result
-	UNION ALL
-	MATCH ()-[]->() RETURN { name:'relationships', data: count(*)} AS result
+export const metaQuery = `CALL db.labels() YIELD label
+RETURN {name:'labels', data:COLLECT(label)[..1000]} AS result
+UNION ALL
+CALL db.relationshipTypes() YIELD relationshipType
+RETURN {name:'relationshipTypes', data:COLLECT(relationshipType)[..1000]} AS result
+UNION ALL
+CALL db.propertyKeys() YIELD propertyKey
+RETURN {name:'propertyKeys', data:COLLECT(propertyKey)[..1000]} AS result
+UNION ALL
+CALL dbms.functions() YIELD name, signature, description
+RETURN {name:'functions', data: collect({name: name, signature: signature, description: description})} AS result
+UNION ALL
+CALL dbms.procedures() YIELD name, signature, description
+RETURN {name:'procedures', data:collect({name: name, signature: signature, description: description})} AS result
+UNION ALL
+MATCH () RETURN { name:'nodes', data:count(*) } AS result
+UNION ALL
+MATCH ()-[]->() RETURN { name:'relationships', data: count(*)} AS result
 `;
 
 export const shortMetaQuery = `  CALL db.labels() YIELD label

--- a/packages/codemirror/css/cypher-codemirror.css
+++ b/packages/codemirror/css/cypher-codemirror.css
@@ -23,41 +23,59 @@ Credits: http://ethanschoonover.com/solarized
 
 SOLARIZED HEX     16/8 TERMCOL  XTERM/HEX   L*A*B      RGB         HSB
 --------- ------- ---- -------  ----------- ---------- ----------- -----------
-base03    #002b36  8/4 brblack  234 #1c1c1c 15 -12 -12   0  43  54 193 100  21
-base02    #073642  0/4 black    235 #262626 20 -12 -12   7  54  66 192  90  26
-base01    #586e75 10/7 brgreen  240 #585858 45 -07 -07  88 110 117 194  25  46
-base00    #657b83 11/7 bryellow 241 #626262 50 -07 -07 101 123 131 195  23  51
-base0     #839496 12/6 brblue   244 #808080 60 -06 -03 131 148 150 186  13  59
-base1     #93a1a1 14/4 brcyan   245 #8a8a8a 65 -05 -02 147 161 161 180   9  63
-base2     #eee8d5  7/7 white    254 #e4e4e4 92 -00  10 238 232 213  44  11  93
-base3     #fdf6e3 15/7 brwhite  230 #ffffd7 97  00  10 253 246 227  44  10  99
-yellow    #b58900  3/3 yellow   136 #af8700 60  10  65 181 137   0  45 100  71
-orange    #cb4b16  9/3 brred    166 #d75f00 50  50  55 203  75  22  18  89  80
-red       #dc322f  1/1 red      160 #d70000 50  65  45 220  50  47   1  79  86
-magenta   #d33682  5/5 magenta  125 #af005f 50  65 -05 211  54 130 331  74  83
-violet    #6c71c4 13/5 brmagenta 61 #5f5faf 50  15 -45 108 113 196 237  45  77
-blue      #268bd2  4/4 blue      33 #0087ff 55 -10 -45  38 139 210 205  82  82
-cyan      #2aa198  6/6 cyan      37 #00afaf 60 -35 -05  42 161 152 175  74  63
-green     #859900  2/2 green     64 #5f8700 60 -20  65 133 153   0  68 100  60
+base03    #002b36  8/4 brblack  234 #1c1c1c 15 -12 -12   0  43  54 193 100  21 !
+base02    #073642  0/4 black    235 #262626 20 -12 -12   7  54  66 192  90  26 !
+base01    #586e75 10/7 brgreen  240 #585858 45 -07 -07  88 110 117 194  25  46 !
+base00    #657b83 11/7 bryellow 241 #626262 50 -07 -07 101 123 131 195  23  51 not any styling applied
+base0     #839496 12/6 brblue   244 #808080 60 -06 -03 131 148 150 186  13  59 !
+base1     #93a1a1 14/4 brcyan   245 #8a8a8a 65 -05 -02 147 161 161 180   9  63 !
+base2     #eee8d5  7/7 white    254 #e4e4e4 92 -00  10 238 232 213  44  11  93 not any styling applied
+base3     #fdf6e3 15/7 brwhite  230 #ffffd7 97  00  10 253 246 227  44  10  99 !
+yellow    #b58900  3/3 yellow   136 #af8700 60  10  65 181 137   0  45 100  71 !
+orange    #cb4b16  9/3 brred    166 #d75f00 50  50  55 203  75  22  18  89  80 Done but also embedded in SVG should fix
+red       #dc322f  1/1 red      160 #d70000 50  65  45 220  50  47   1  79  86 Done but also embedded in SVG should fix
+magenta   #d33682  5/5 magenta  125 #af005f 50  65 -05 211  54 130 331  74  83 Done but also embedded in SVG should fix
+violet    #6c71c4 13/5 brmagenta 61 #5f5faf 50  15 -45 108 113 196 237  45  77 Done but also embedded in SVG should fix
+blue      #268bd2  4/4 blue      33 #0087ff 55 -10 -45  38 139 210 205  82  82 Done but also embedded in SVG should fix
+cyan      #2aa198  6/6 cyan      37 #00afaf 60 -35 -05  42 161 152 175  74  63 !
+green     #859900  2/2 green     64 #5f8700 60 -20  65 133 153   0  68 100  60 !
  */
 
+/*
+    The full color palette is available at:
+    https://storybook-components-build.appspot.com/?path=/docs/foundation-color-palette--color-palette#light-theme
+*/
+@import url("https://cdn.jsdelivr.net/npm/@neo4j-ndl/base@latest/lib/tokens/css/tokens.css");
+@import url('https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500');
+
+
 .cm-editor {
-    background-color: #ffffff;
+    background-color: rgb(var(--palette-light-neutral-bg-weak));
     line-height: 1.4375;
-    color: #657b83;
+    color: rgb(var(--palette-light-neutral-text-default));
     text-align: left;
 }
 
 .cm-editor .cm-content ::selection {
-    background-color: #d7d4f0;
+    background-color: rgb(var(--palette-light-neutral-text-weak));;
+}
+
+.cm-editor.cm-focused .cm-selectionBackground,
+.cm-editor .cm-selectionBackground{
+    background: rgb(var(--colors-neutral-40));
+}
+.cm-editor.cm-focused.cm-dark .cm-selectionBackground,
+.cm-editor.cm-dark .cm-selectionBackground{
+    background: rgb(var(--colors-neutral-80));
 }
 
 .cm-editor.cm-dark {
-    background-color: #002b36;
-    color: #839496;
+    background-color: rgb(var(--colors-neutral-90));
+    color: rgb(var(--colors-neutral-50));
 }
 
 .cm-editor .cm-lineNumbers .cm-gutterElement {
+    font-family: "Fira Code";
     padding: 0 5px 0 5px;
 }
 
@@ -65,9 +83,9 @@ green     #859900  2/2 green     64 #5f8700 60 -20  65 133 153   0  68 100  60
     border: none;
     padding-left: 5px;
     padding-right: 3px;
-    background-color: #ffffff;
-    /* background-color: #eee8d5; */
-    border-right: 3px solid #fdf6e3;
+    background-color: rgb(var(--palette-light-neutral-bg-weak));
+    /*Currently transparent */
+    /*border-right: 3px solid rgb(var(--colors-warning-10));*/
 }
 
 .cm-editor .cm-gutter {
@@ -76,6 +94,7 @@ green     #859900  2/2 green     64 #5f8700 60 -20  65 133 153   0  68 100  60
 
 .cm-editor .cm-content .cm-line {
     line-height: 1.4375;
+    font-family: "Fira Code";
 }
 
 .cm-editor .cm-scroller .cm-content,
@@ -84,41 +103,49 @@ green     #859900  2/2 green     64 #5f8700 60 -20  65 133 153   0  68 100  60
 }
 
 .cm-editor.cm-dark .cm-gutters {
-    background-color: #073642;
-    border-right: 3px solid #002b36;
+    background-color: rgb(var(--colors-neutral-80));
+    border-right: 3px solid rgb(var(--colors-neutral-90));
 }
 
 .cm-editor .cm-cursor {
     z-index: 1;
-    border-left: 0.67em solid rgba(147, 161, 161, 0.37);
+    border-left: 0.67em solid rgba(var(--colors-neutral-70), 0.37);
 }
 
 .cm-editor.cm-dark .cm-cursor {
-    background-color: rgba(131, 148, 150, 0.37);
+    background-color: rgba(var(--colors-neutral-50), 0.37);
 }
 
 .cm-editor .cm-comment {
-    color: #93a1a1;
+    color: rgb(var(--colors-neutral-40));
 }
 
 .cm-editor.cm-dark .cm-comment {
-    color: #586e75;
+    color: rgb(var(--colors-neutral-70));
 }
 
 .cm-editor .cm-string {
-    color: #b58900;
+    color: rgb(var(--colors-warning-60));
+}
+
+.cm-editor.cm-dark .cm-string {
+    color: rgb(var(--colors-warning-40));
 }
 
 .cm-editor .cm-number {
-    color: #2aa198;
+    color: rgb(var(--colors-blueberry-30));
 }
 
 .cm-editor .cm-operator {
 }
 
 .cm-editor .cm-keyword {
-    color: #859900;
+    color: rgb(var(--colors-success-50));
 }
+.cm-editor.cm-dark .cm-keyword {
+    color: rgb(var(--colors-success-40));
+}
+
 
 /***********
  * Parser
@@ -126,55 +153,56 @@ green     #859900  2/2 green     64 #5f8700 60 -20  65 133 153   0  68 100  60
 
 .cm-editor .cm-p-label,
 .cm-editor .cm-p-label .cm-keyword {
-    color: #cb4b16;
+    color: rgb(var(--colors-danger-40));
 }
 
 .cm-editor .cm-p-relationshipType,
 .cm-editor .cm-p-relationshipType .cm-keyword {
-    color: #cb4b16;
+    color: rgb(var(--colors-danger-40));
 }
 
 .cm-editor .cm-p-variable,
 .cm-editor .cm-p-variable .cm-keyword {
-    color: #268bd2;
+    color: rgb(var(--colors-primary-40));
 }
 
 .cm-editor .cm-p-procedure,
 .cm-editor .cm-p-procedure .cm-keyword {
-    color: #6c71c4;
+    color: rgb(var(--colors-blueberry-40));
 }
 
 .cm-editor .cm-p-function,
 .cm-editor .cm-p-function .cm-keyword {
-    color: #6c71c4;
+    color: rgb(var(--colors-blueberry-40));
 }
 
 .cm-editor .cm-p-parameter,
 .cm-editor .cm-p-parameter .cm-keyword {
-    color: #dc322f;
+    color: rgb(var(--colors-danger-50));
 }
 
 .cm-editor .cm-p-property,
 .cm-editor .cm-p-property .cm-keyword {
-    color: #586e75;
+    color: rgb(var(--colors-neutral-70));
 }
 
 .cm-editor.cm-dark .cm-p-property,
 .cm-editor.cm-dark .cm-p-property .cm-keyword {
-    color: #93a1a1;
+    color: rgb(var(--colors-neutral-40));
 }
 
 .cm-editor .cm-p-consoleCommand,
 .cm-editor .cm-p-consoleCommand .cm-keyword {
-    color: #d33682;
+    color: rgb(var(--colors-danger-30));
 }
 
 .cm-editor .cm-p-procedureOutput,
 .cm-editor .cm-p-procedureOutput .cm-keyword {
-    color: #268bd2;
+    color: rgb(var(--colors-primary-40));
 }
 
 .cm-completionLabel {
+    font-family: "Fira Code";
     font-weight: bold;
     vertical-align: middle;
 }
@@ -186,6 +214,14 @@ green     #859900  2/2 green     64 #5f8700 60 -20  65 133 153   0  68 100  60
 }
 
 .cm-editor .cm-completionIcon-keyword:after {
+    /*font-family: "Fira Code";*/
+    /*background-color: red;*/
+    /*content: "K";*/
+    /*border-radius: 100%;*/
+    /*width: 20px;*/
+    /*height: 20px;*/
+    /*display: block;*/
+    /*line-height: 22px;*/
     content: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' version='1.1' viewBox='0 0 40 40'><circle cx='20' cy='20' r='19' stroke='black' stroke-width='1' fill='white'></circle><text x='50%' y='50%' text-anchor='middle' dy='.35em' font-size='28' font-family='Monaco' fill='%23cb4b16'>K</text></svg>");
 }
 


### PR DESCRIPTION
Tried integrating Needle 🪡  design tokens to the Cypher editor. The work is almost done, but have some problems and some guidance would help me.

As of today, we were using Solarised variables to work in `light` and `dark` theme, so I tried as much as it was feasible to map the values to [current color tokens](https://storybook-components-build.appspot.com/?path=/docs/foundation-color-palette--color-palette), with some exceptions that will discuss below.

The current mapping can be seen in the attached image 👇

<p align="center">
    <img src="https://user-images.githubusercontent.com/12672541/206546733-226203fb-a112-497e-b623-e072166b64ce.png" width="600" />
</p>

### What this PR includes

#### 1. Accessibility

The `yellow` color from Solarised is changed as it was failing the accessibility test and it is not a great experience if we have a white background as the current Query editor. 
Thus, I applied a different `yellow` and `green` value for `light` vs `dark` theme. Just to note that the current goal is to test for AA and not AAA, [more here](https://design.neo4j.com/40a8cff71/v/0/p/215b5e-accessibility/t/20a8df).

<table>
  <tr>
    <td>Default yellow colour</td>
     <td>Accessibility failure</td>
  </tr>
  <tr>
    <td valign="top"><img src="https://user-images.githubusercontent.com/12672541/206547614-ca820df9-2062-48a2-a3f7-d03912cc8002.png"></td>
    <td valign="top"><img src="https://user-images.githubusercontent.com/12672541/206547636-24ab9158-b35e-40b6-8530-109867ff6d51.png"></td>
  </tr>
 </table>

Also some additional a11y failures that will change probably in the future.

<table>
  <tr>
    <td valign="top"><img src="https://user-images.githubusercontent.com/12672541/206548748-776f3384-c839-470e-b822-590d7036f592.png"></td>
    <td valign="top"><img src="https://user-images.githubusercontent.com/12672541/206548757-805f3c50-d423-44d8-8352-b7d401fbf84b.png"></td>
  </tr>
 </table>

#### 2. Different parsing

Not related to this PR, but currently I can see that Query cypher editor has different parsing from this editor for exactly the same query. Is this expected?

![CleanShot 2022-12-08 at 18 10 51](https://user-images.githubusercontent.com/12672541/206548104-44d6edb5-1d33-464e-96c0-6ad9d12be740.png)

#### 3. SVG fill

On some colours you will notice that I state a partial refactoring, [like here](https://github.com/neo4j-contrib/cypher-editor/compare/next...konsalex:cypher-editor:integrate-needle-tokens?expand=1#diff-3f594720610fd6a57883230d1c917fdc75dfe2eb68cd8226de1ee658d3cfbd82R35). 

This is because some of the colours are included as `fills` in the `url()` loaded SVGs. The problem with this approach is that the fill should be hardcoded and escaped, as an example `fill='%23cb4b16'`, which technically beats the whole purpose of sharable tokens. If you know any way to use a variable here that will be awesome but couldn't find something that works, as I think that the svg loaded with a `url()` is not a "part" of the DOM and cannot access css variables.

I have commented another way of implementing those SVG circles with pure CSS, but not sure if you already tried and you had a roadblock. The code is [like this one](https://github.com/neo4j-contrib/cypher-editor/compare/next...konsalex:cypher-editor:integrate-needle-tokens?expand=1#diff-3f594720610fd6a57883230d1c917fdc75dfe2eb68cd8226de1ee658d3cfbd82R219). If you are ok with this way I can refactor the rest of the classes and use the css variables.

