### PR TITLE
add keyUp option/prop, open autocomplete on keyUp

### DIFF
--- a/.changeset/many-hornets-mix.md
+++ b/.changeset/many-hornets-mix.md
@@ -1,0 +1,7 @@
+---
+"@neo4j-cypher/svelte-codemirror": patch
+"@neo4j-cypher/react-codemirror": patch
+"@neo4j-cypher/codemirror": patch
+---
+
+add keyUp option/prop, improve autocomplete trigger logic

--- a/demos/demo-base-react/src/Database.js
+++ b/demos/demo-base-react/src/Database.js
@@ -265,6 +265,18 @@ const Database = ({ CypherEditor, codemirrorVersion, framework, bundler }) => {
     });
   };
 
+  const onKeyUp = (event) => {
+    const { code, altKey, key, controlKey, metaKey, shiftKey } = event;
+    addEventLog("keyUp", {
+      code,
+      altKey,
+      key,
+      controlKey,
+      metaKey,
+      shiftKey
+    });
+  };
+
   const cypherLength = cypher.length;
   const positionString = position ? JSON.stringify(position) : "";
   const focusedString = focused + "";
@@ -1333,6 +1345,7 @@ const Database = ({ CypherEditor, codemirrorVersion, framework, bundler }) => {
             onValueChanged={onValueChanged}
             onLineNumberClick={onLineNumberClick}
             onKeyDown={onKeyDown}
+            onKeyUp={onKeyUp}
             autocomplete={autocomplete}
             autocompleteCloseOnBlur={autocompleteCloseOnBlur}
             autocompleteOpen={autocompleteOpen}

--- a/demos/demo-base-svelte/src/Database.svelte
+++ b/demos/demo-base-svelte/src/Database.svelte
@@ -176,6 +176,13 @@
     );
   };
 
+  const onKeyUp = (event) => {
+    const { code, altKey, key, controlKey, metaKey, shiftKey } = event;
+    logs = logs.concat(
+      eventLog("keyUp", { code, altKey, key, controlKey, metaKey, shiftKey })
+    );
+  };
+
   const onLineNumberClick = (line, event) => {
     logs = logs.concat(eventLog("lineNumberClick", line));
   };
@@ -895,6 +902,7 @@
         {onValueChanged}
         {onLineNumberClick}
         {onKeyDown}
+        {onKeyUp}
         {autocomplete}
         {autocompleteOpen}
         {autocompleteCloseOnBlur}

--- a/demos/demo-base/src/index.js
+++ b/demos/demo-base/src/index.js
@@ -283,6 +283,7 @@ export const eventTypes = [
   "focusChanged",
   "lineNumberClick",
   "keyDown",
+  "keyUp",
   "positionChanged",
   "scrollChanged",
   "valueChanged",

--- a/docs/generated/neo4j-cypher_codemirror.md
+++ b/docs/generated/neo4j-cypher_codemirror.md
@@ -61,7 +61,7 @@ An editor api that wraps the created editor instance
 |  [AutocompleteChangedListener](#autocompletechangedlistener) | Listener for editor autocomplete changes |
 |  [EditorCreatedListener](#editorcreatedlistener) | Listener for editor creation |
 |  [FocusChangedListener](#focuschangedlistener) | Listener for editor focus changes |
-|  [KeyDownListener](#keydownlistener) | Listener for editor key down events |
+|  [KeyListener](#keylistener) | Listener for editor key events |
 |  [LineNumberClickListener](#linenumberclicklistener) | Listener for editor line number click events |
 |  [LineNumberFormatter](#linenumberformatter) | Formats a line number for display beside the editor text |
 |  [PositionChangedListener](#positionchangedlistener) | Listener for editor cursor position changes |
@@ -152,16 +152,16 @@ void
 
 <br>
 
-<a name="keydownlistener"></a>
+<a name="keylistener"></a>
 
-### KeyDownListener call signature
+### KeyListener call signature
 
-Listener for editor key down events
+Listener for editor key events
 
 <b>Signature:</b>
 
 ```typescript
-export interface KeyDownListener {
+export interface KeyListener {
   (event: KeyboardEvent): void;
 }
 ```
@@ -501,6 +501,7 @@ editorSupport: CypherEditorSupport;
 |  [offAutocompleteChanged(listener)](#editorapi.offautocompletechanged) | Remove an event listener for editor autocomplete changes |
 |  [offFocusChanged(listener)](#editorapi.offfocuschanged) | Remove an event listener for editor focus changes |
 |  [offKeyDown(listener)](#editorapi.offkeydown) | Remove an event listener for editor key down events |
+|  [offKeyUp(listener)](#editorapi.offkeyup) | Remove an event listener for editor key up events |
 |  [offLineNumberClick(listener)](#editorapi.offlinenumberclick) | Remove an event listener for editor line number click events |
 |  [offPositionChanged(listener)](#editorapi.offpositionchanged) | Remove an event listener for editor curosor position changes |
 |  [offScrollChanged(listener)](#editorapi.offscrollchanged) | Remove an event listener for editor scroll position changes |
@@ -509,6 +510,7 @@ editorSupport: CypherEditorSupport;
 |  [onAutocompleteChanged(listener)](#editorapi.onautocompletechanged) | Add an event listener for editor autocomplete changes |
 |  [onFocusChanged(listener)](#editorapi.onfocuschanged) | Add an event listener for editor focus changes |
 |  [onKeyDown(listener)](#editorapi.onkeydown) | Add an event listener for editor key down events |
+|  [onKeyUp(listener)](#editorapi.onkeyup) | Add an event listener for editor key up events |
 |  [onLineNumberClick(listener)](#editorapi.onlinenumberclick) | Add an event listener for editor line number click events |
 |  [onPositionChanged(listener)](#editorapi.onpositionchanged) | Add an event listener for editor cursor position changes |
 |  [onScrollChanged(listener)](#editorapi.onscrollchanged) | Add an event listener for editor scroll position changes |
@@ -711,13 +713,36 @@ Remove an event listener for editor key down events
 <b>Signature:</b>
 
 ```typescript
-offKeyDown(listener: KeyDownListener): void;
+offKeyDown(listener: KeyListener): void;
 ```
 <b>Parameters:</b>
 
 |  Parameter | Type |
 |  --- | --- |
-|  listener | [KeyDownListener](#keydownlistener) |
+|  listener | [KeyListener](#keylistener) |
+
+<b>Returns:</b>
+
+void
+
+<br>
+
+<a name="editorapi.offkeyup"></a>
+
+#### EditorApi.offKeyUp() method
+
+Remove an event listener for editor key up events
+
+<b>Signature:</b>
+
+```typescript
+offKeyUp(listener: KeyListener): void;
+```
+<b>Parameters:</b>
+
+|  Parameter | Type |
+|  --- | --- |
+|  listener | [KeyListener](#keylistener) |
 
 <b>Returns:</b>
 
@@ -899,13 +924,38 @@ Add an event listener for editor key down events
 <b>Signature:</b>
 
 ```typescript
-onKeyDown(listener: KeyDownListener): () => void;
+onKeyDown(listener: KeyListener): () => void;
 ```
 <b>Parameters:</b>
 
 |  Parameter | Type |
 |  --- | --- |
-|  listener | [KeyDownListener](#keydownlistener) |
+|  listener | [KeyListener](#keylistener) |
+
+<b>Returns:</b>
+
+() =&gt; void
+
+A cleanup function that when called removes the listener
+
+<br>
+
+<a name="editorapi.onkeyup"></a>
+
+#### EditorApi.onKeyUp() method
+
+Add an event listener for editor key up events
+
+<b>Signature:</b>
+
+```typescript
+onKeyUp(listener: KeyListener): () => void;
+```
+<b>Parameters:</b>
+
+|  Parameter | Type |
+|  --- | --- |
+|  listener | [KeyListener](#keylistener) |
 
 <b>Returns:</b>
 

--- a/docs/generated/neo4j-cypher_react-codemirror.md
+++ b/docs/generated/neo4j-cypher_react-codemirror.md
@@ -99,7 +99,8 @@ export interface CypherEditorProps
 |  [onAutocompleteChanged?](#cyphereditorprops.onautocompletechanged) | [AutocompleteChangedListener](./neo4j-cypher_codemirror.md#autocompletechangedlistener) |  | <i>(Optional)</i> A listener for when the editor autocompletion state changes |
 |  [onEditorCreated?](#cyphereditorprops.oneditorcreated) | [EditorCreatedListener](./neo4j-cypher_codemirror.md#editorcreatedlistener) |  | <i>(Optional)</i> A listener for when the editor api gets created |
 |  [onFocusChanged?](#cyphereditorprops.onfocuschanged) | [FocusChangedListener](./neo4j-cypher_codemirror.md#focuschangedlistener) |  | <i>(Optional)</i> A listener for when the editor focus changes |
-|  [onKeyDown?](#cyphereditorprops.onkeydown) | [KeyDownListener](./neo4j-cypher_codemirror.md#keydownlistener) |  | <i>(Optional)</i> A listener for when the user presses a key down in the editor |
+|  [onKeyDown?](#cyphereditorprops.onkeydown) | [KeyListener](./neo4j-cypher_codemirror.md#keylistener) |  | <i>(Optional)</i> A listener for when the user performs a key down in the editor |
+|  [onKeyUp?](#cyphereditorprops.onkeyup) | [KeyListener](./neo4j-cypher_codemirror.md#keylistener) |  | <i>(Optional)</i> A listener for when the user performs a key up in the editor |
 |  [onLineNumberClick?](#cyphereditorprops.onlinenumberclick) | [LineNumberClickListener](./neo4j-cypher_codemirror.md#linenumberclicklistener) |  | <i>(Optional)</i> A listener for when the user clicks an editor line number |
 |  [onPositionChanged?](#cyphereditorprops.onpositionchanged) | [PositionChangedListener](./neo4j-cypher_codemirror.md#positionchangedlistener) |  | <i>(Optional)</i> A listener for when the editor cursor position changes |
 |  [onScrollChanged?](#cyphereditorprops.onscrollchanged) | [ScrollChangedListener](./neo4j-cypher_codemirror.md#scrollchangedlistener) |  | <i>(Optional)</i> A listener for when the editor scroll position changes |
@@ -492,12 +493,26 @@ onFocusChanged?: FocusChangedListener;
 
 #### CypherEditorProps.onKeyDown property
 
-A listener for when the user presses a key down in the editor
+A listener for when the user performs a key down in the editor
 
 <b>Signature:</b>
 
 ```typescript
-onKeyDown?: KeyDownListener;
+onKeyDown?: KeyListener;
+```
+
+<br>
+
+<a name="cyphereditorprops.onkeyup"></a>
+
+#### CypherEditorProps.onKeyUp property
+
+A listener for when the user performs a key up in the editor
+
+<b>Signature:</b>
+
+```typescript
+onKeyUp?: KeyListener;
 ```
 
 <br>

--- a/docs/generated/neo4j-cypher_svelte-codemirror.md
+++ b/docs/generated/neo4j-cypher_svelte-codemirror.md
@@ -100,7 +100,8 @@ export interface CypherEditorProps
 |  [onAutocompleteChanged?](#cyphereditorprops.onautocompletechanged) | [AutocompleteChangedListener](./neo4j-cypher_codemirror.md#autocompletechangedlistener) |  | <i>(Optional)</i> A listener for when the editor autocompletion state changes |
 |  [onEditorCreated?](#cyphereditorprops.oneditorcreated) | [EditorCreatedListener](./neo4j-cypher_codemirror.md#editorcreatedlistener) |  | <i>(Optional)</i> A listener for when the editor api gets created |
 |  [onFocusChanged?](#cyphereditorprops.onfocuschanged) | [FocusChangedListener](./neo4j-cypher_codemirror.md#focuschangedlistener) |  | <i>(Optional)</i> A listener for when the editor focus changes |
-|  [onKeyDown?](#cyphereditorprops.onkeydown) | [KeyDownListener](./neo4j-cypher_codemirror.md#keydownlistener) |  | <i>(Optional)</i> A listener for when the user presses a key down in the editor |
+|  [onKeyDown?](#cyphereditorprops.onkeydown) | [KeyListener](./neo4j-cypher_codemirror.md#keylistener) |  | <i>(Optional)</i> A listener for when the user performs a key down in the editor |
+|  [onKeyUp?](#cyphereditorprops.onkeyup) | [KeyListener](./neo4j-cypher_codemirror.md#keylistener) |  | <i>(Optional)</i> A listener for when the user performs a key up in the editor |
 |  [onLineNumberClick?](#cyphereditorprops.onlinenumberclick) | [LineNumberClickListener](./neo4j-cypher_codemirror.md#linenumberclicklistener) |  | <i>(Optional)</i> A listener for when the user clicks an editor line number |
 |  [onPositionChanged?](#cyphereditorprops.onpositionchanged) | [PositionChangedListener](./neo4j-cypher_codemirror.md#positionchangedlistener) |  | <i>(Optional)</i> A listener for when the editor cursor position changes |
 |  [onScrollChanged?](#cyphereditorprops.onscrollchanged) | [ScrollChangedListener](./neo4j-cypher_codemirror.md#scrollchangedlistener) |  | <i>(Optional)</i> A listener for when the editor scroll position changes |
@@ -493,12 +494,26 @@ onFocusChanged?: FocusChangedListener;
 
 #### CypherEditorProps.onKeyDown property
 
-A listener for when the user presses a key down in the editor
+A listener for when the user performs a key down in the editor
 
 <b>Signature:</b>
 
 ```typescript
-onKeyDown?: KeyDownListener;
+onKeyDown?: KeyListener;
+```
+
+<br>
+
+<a name="cyphereditorprops.onkeyup"></a>
+
+#### CypherEditorProps.onKeyUp property
+
+A listener for when the user performs a key up in the editor
+
+<b>Signature:</b>
+
+```typescript
+onKeyUp?: KeyListener;
 ```
 
 <br>

--- a/packages/codemirror/src/codemirror.d.ts
+++ b/packages/codemirror/src/codemirror.d.ts
@@ -224,9 +224,9 @@ export interface ValueChangedListener {
 }
 
 /**
- * Listener for editor key down events
+ * Listener for editor key events
  */
-export interface KeyDownListener {
+export interface KeyListener {
   /**
    * @param event - the native keyboard event
    */
@@ -434,11 +434,21 @@ export interface EditorApi {
    *
    * @returns A cleanup function that when called removes the listener
    */
-  onKeyDown(listener: KeyDownListener): () => void;
+  onKeyDown(listener: KeyListener): () => void;
   /**
    * Remove an event listener for editor key down events
    */
-  offKeyDown(listener: KeyDownListener): void;
+  offKeyDown(listener: KeyListener): void;
+  /**
+   * Add an event listener for editor key up events
+   *
+   * @returns A cleanup function that when called removes the listener
+   */
+  onKeyUp(listener: KeyListener): () => void;
+  /**
+   * Remove an event listener for editor key up events
+   */
+  offKeyUp(listener: KeyListener): void;
   /**
    * Add an event listener for editor line number click events
    *

--- a/packages/codemirror/src/codemirror.js
+++ b/packages/codemirror/src/codemirror.js
@@ -315,7 +315,8 @@ export function createCypherEditor(parentDOMElement, options = {}) {
       !event.ctrlKey &&
       !event.altKey &&
       event.key &&
-      event.key.length === 1
+      event.key.length > 0 &&
+      event.key.length < 3
         ? event.key
         : null;
     fireKeyDown(event);
@@ -351,7 +352,6 @@ export function createCypherEditor(parentDOMElement, options = {}) {
           inserted.text.length == 1
         ) {
           changedText = inserted.text[0];
-          // { {}
         }
       });
 

--- a/packages/codemirror/src/codemirror.js
+++ b/packages/codemirror/src/codemirror.js
@@ -357,7 +357,7 @@ export function createCypherEditor(parentDOMElement, options = {}) {
 
       if (
         changedText &&
-        autocompleteTriggerStrings.indexOf(changedText) !== -1
+        autocompleteTriggerStrings.includes(changedText)
       ) {
         deferredAutocomplete = true;
       }

--- a/packages/codemirror/src/codemirror.js
+++ b/packages/codemirror/src/codemirror.js
@@ -315,8 +315,7 @@ export function createCypherEditor(parentDOMElement, options = {}) {
       !event.ctrlKey &&
       !event.altKey &&
       event.key &&
-      event.key.length > 0 &&
-      event.key.length < 3
+      event.key.length === 1
         ? event.key
         : null;
     fireKeyDown(event);

--- a/packages/codemirror/src/codemirror.js
+++ b/packages/codemirror/src/codemirror.js
@@ -118,7 +118,8 @@ export const getExtensions = (
     onLineNumberClick = () => {},
     onFocusChanged = () => {},
     onScrollChanged = () => {},
-    onKeyDown = () => {}
+    onKeyDown = () => {},
+    onKeyUp = () => {}
   } = {}
 ) => {
   const combinedOptions = withDefaultOptions(options);
@@ -146,7 +147,7 @@ export const getExtensions = (
   } = combinedOptions;
 
   return [
-    domListener({ onFocusChanged, onScrollChanged, onKeyDown }),
+    domListener({ onFocusChanged, onScrollChanged, onKeyDown, onKeyUp }),
     cypherLanguageConf.of(getCypherLanguageExtensions({ cypherLanguage })),
     lintConf.of(getLintExtensions({ cypherLanguage, readOnly, lint })),
     autocompleteConf.of(
@@ -243,6 +244,8 @@ export function createCypherEditor(parentDOMElement, options = {}) {
   let lastPosition = null;
   let searchInitializing = false;
   let detectedThemeDark = theme === "auto" ? detectThemeDark() : null;
+  let pressedKey = null;
+  let deferredAutocomplete = false;
 
   const setDetectedThemeDark = (dark) => {
     detectedThemeDark = dark;
@@ -300,43 +303,69 @@ export function createCypherEditor(parentDOMElement, options = {}) {
     fire: fireKeyDown
   } = createEventHandlers();
 
+  const { on: onKeyUp, off: offKeyUp, fire: fireKeyUp } = createEventHandlers();
+
   const lineNumberClick = (line, event) => {
     fireLineNumberClick(line, event);
   };
 
   const keyDown = (event) => {
+    pressedKey =
+      !event.metaKey &&
+      !event.ctrlKey &&
+      !event.altKey &&
+      event.key &&
+      event.key.length === 1
+        ? event.key
+        : null;
     fireKeyDown(event);
   };
 
-  const handleValueChanged = (value, changes) => {
+  const keyUp = (event) => {
+    if (deferredAutocomplete) {
+      showAutocomplete();
+      deferredAutocomplete = false;
+    }
+
+    pressedKey = null;
+    fireKeyUp(event);
+  };
+
+  const deferAutocompleteForChanges = (changes) => {
+    const { length = 0, newLength = 0 } = changes;
+    const isSmallInsert = newLength > length && newLength - length <= 2;
     if (
+      pressedKey &&
       cypherLanguage &&
       autocomplete &&
-      Array.isArray(autocompleteTriggerStrings)
+      Array.isArray(autocompleteTriggerStrings) &&
+      isSmallInsert
     ) {
-      let changedText = [];
+      let changedText = null;
       changes.iterChanges((fromA, toA, fromB, toB, inserted) => {
-        // If changes have more than 32 lines, inserted will have a children property
-        // with 32 lines in each child.
-        if (inserted.children) {
-          changedText = inserted.children.map((c) => c.text);
-          return;
+        if (
+          !changedText &&
+          inserted &&
+          typeof inserted === "object" &&
+          Array.isArray(inserted.text) &&
+          inserted.text.length == 1
+        ) {
+          changedText = inserted.text[0];
+          // { {}
         }
-        changedText = inserted.text;
       });
 
-      if (changedText.length > 0 && changedText.length <= 2) {
-        const text = changedText[0];
-        if (autocompleteTriggerStrings.indexOf(text) !== -1) {
-          showDeferredAutocomplete();
-        } else if (changedText.length === 2) {
-          const longerText = text + changedText[1];
-          if (autocompleteTriggerStrings.indexOf(longerText) !== -1) {
-            showDeferredAutocomplete();
-          }
-        }
+      if (
+        changedText &&
+        autocompleteTriggerStrings.indexOf(changedText) !== -1
+      ) {
+        deferredAutocomplete = true;
       }
     }
+  };
+
+  const handleValueChanged = (value, changes) => {
+    deferAutocompleteForChanges(changes);
 
     fireValueChanged(value, changes);
   };
@@ -495,7 +524,8 @@ export function createCypherEditor(parentDOMElement, options = {}) {
         onLineNumberClick: lineNumberClick,
         onFocusChanged: handleFocusChanged,
         onScrollChanged: handleScrollChanged,
-        onKeyDown: keyDown
+        onKeyDown: keyDown,
+        onKeyUp: keyUp
       }),
       updateListener,
       postConf.of(postExtensions)
@@ -533,18 +563,6 @@ export function createCypherEditor(parentDOMElement, options = {}) {
         );
       }
     }
-  };
-
-  let deferredAutocomplete = false;
-
-  const showDeferredAutocomplete = () => {
-    deferredAutocomplete = true;
-    setTimeout(() => {
-      if (deferredAutocomplete) {
-        deferredAutocomplete = false;
-        showAutocomplete();
-      }
-    }, 50);
   };
 
   const showAutocomplete = () => {
@@ -1080,6 +1098,8 @@ export function createCypherEditor(parentDOMElement, options = {}) {
     offFocusChanged,
     onKeyDown,
     offKeyDown,
+    onKeyUp,
+    offKeyUp,
     onLineNumberClick,
     offLineNumberClick,
     onPositionChanged,

--- a/packages/codemirror/src/cypher-extensions.js
+++ b/packages/codemirror/src/cypher-extensions.js
@@ -87,7 +87,8 @@ export const fixColors = (view, editorSupport) => {
 export const domListener = ({
   onFocusChanged = () => {},
   onScrollChanged = () => {},
-  onKeyDown = () => {}
+  onKeyDown = () => {},
+  onKeyUp = () => {}
 }) => [
   EditorView.domEventHandlers({
     focus: () => {
@@ -118,6 +119,9 @@ export const domListener = ({
     },
     keydown: (event) => {
       onKeyDown(event);
+    },
+    keyup: (event) => {
+      onKeyUp(event);
     }
   })
 ];

--- a/packages/react-codemirror/src/CypherEditor.d.ts
+++ b/packages/react-codemirror/src/CypherEditor.d.ts
@@ -12,7 +12,7 @@ import type {
   ScrollChangedListener,
   SearchChangedListener,
   ValueChangedListener,
-  KeyDownListener,
+  KeyListener,
   LineNumberClickListener,
   LineNumberFormatter
 } from "@neo4j-cypher/codemirror";
@@ -265,9 +265,13 @@ export interface CypherEditorProps {
    */
   onLineNumberClick?: LineNumberClickListener;
   /**
-   * A listener for when the user presses a key down in the editor
+   * A listener for when the user performs a key down in the editor
    */
-  onKeyDown?: KeyDownListener;
+  onKeyDown?: KeyListener;
+  /**
+   * A listener for when the user performs a key up in the editor
+   */
+  onKeyUp?: KeyListener;
 
   /**
    * The codemirror 6 extensions that should be added to the editor before the cypher language support extensions.

--- a/packages/react-codemirror/src/CypherEditor.js
+++ b/packages/react-codemirror/src/CypherEditor.js
@@ -63,6 +63,11 @@ class CypherEditor extends Component {
     onKeyDown && onKeyDown(event);
   };
 
+  keyUp = (event) => {
+    const { onKeyUp } = this.props;
+    onKeyUp && onKeyUp(event);
+  };
+
   componentDidMount() {
     const {
       autocomplete,
@@ -145,6 +150,7 @@ class CypherEditor extends Component {
     this.cypherEditor.onSearchChanged(this.searchChanged);
     this.cypherEditor.onLineNumberClick(this.lineNumberClick);
     this.cypherEditor.onKeyDown(this.keyDown);
+    this.cypherEditor.onKeyUp(this.keyUp);
 
     onEditorCreated && onEditorCreated(this.cypherEditor);
   }
@@ -159,6 +165,7 @@ class CypherEditor extends Component {
       this.cypherEditor.offSearchChanged(this.searchChanged);
       this.cypherEditor.offLineNumberClick(this.lineNumberClick);
       this.cypherEditor.offKeyDown(this.keyDown);
+      this.cypherEditor.offKeyUp(this.keyUp);
 
       this.cypherEditor.destroy();
     }

--- a/packages/svelte-codemirror/src/CypherEditor.svelte
+++ b/packages/svelte-codemirror/src/CypherEditor.svelte
@@ -111,6 +111,7 @@
   export let onAutocompleteChanged = undefined;
   export let onLineNumberClick = undefined;
   export let onKeyDown = undefined;
+  export let onKeyUp = undefined;
 
   let isFocused = false;
   let cypherEditorRef;
@@ -196,6 +197,10 @@
     onKeyDown && onKeyDown(event);
   };
 
+  const keyUp = (event) => {
+    onKeyUp && onKeyUp(event);
+  };
+
   onMount(() => {
     const { editor } = createCypherEditor(cypherEditorRef, {
       autocomplete,
@@ -240,6 +245,7 @@
     cypherEditor.onSearchChanged(searchChanged);
     cypherEditor.onLineNumberClick(lineNumberClick);
     cypherEditor.onKeyDown(keyDown);
+    cypherEditor.onKeyUp(keyUp);
 
     onEditorCreated && onEditorCreated(cypherEditor);
   });
@@ -254,6 +260,7 @@
       cypherEditor.offSearchChanged(searchChanged);
       cypherEditor.offLineNumberClick(lineNumberClick);
       cypherEditor.offKeyDown(keyDown);
+      cypherEditor.offKeyUp(keyUp);
 
       cypherEditor.destroy();
     }

--- a/packages/svelte-codemirror/src/CypherEditor.svelte.d.ts
+++ b/packages/svelte-codemirror/src/CypherEditor.svelte.d.ts
@@ -13,7 +13,7 @@ import type {
   ScrollChangedListener,
   SearchChangedListener,
   ValueChangedListener,
-  KeyDownListener,
+  KeyListener,
   LineNumberClickListener,
   LineNumberFormatter
 } from "@neo4j-cypher/codemirror";
@@ -266,9 +266,13 @@ export interface CypherEditorProps {
    */
   onLineNumberClick?: LineNumberClickListener;
   /**
-   * A listener for when the user presses a key down in the editor
+   * A listener for when the user performs a key down in the editor
    */
-  onKeyDown?: KeyDownListener;
+  onKeyDown?: KeyListener;
+  /**
+   * A listener for when the user performs a key up in the editor
+   */
+  onKeyUp?: KeyListener;
 
   /**
    * The codemirror 6 extensions that should be added to the editor before the cypher language support extensions.


### PR DESCRIPTION
Added a `keyUp` option/prop to complement existing `keyDown` option/prop.

Previously, the editor change listener was checking each and every change against the autocomplete trigger strings.

The new code only checks changes for autocomplete trigger strings if:
- The change was triggered by the user typing a character (any string of length 1).
- The change has a new length that is 1 or 2 characters more than the old length.

Additionally, the new code now uses `keyUp` to open the autocomplete when needed instead of a hacky setTimeout.