### PR TITLE
specify cypher comment format to enable comment shortcuts

### DIFF
--- a/packages/codemirror/src/cypher.js
+++ b/packages/codemirror/src/cypher.js
@@ -150,5 +150,8 @@ export const cypher = {
     if (context.type === "keywords") return null; // return CodeMirror.commands.newlineAndIndent;
     if (context.align) return context.col + (closing ? 0 : 1);
     return context.indent + (closing ? 0 : cx.unit);
+  },
+  languageData: {
+    commentTokens: { line: "//", block: { open: "/*", close: "*/" } }
   }
 };


### PR DESCRIPTION
This change makes the default keybindings for commenting out code work:
- Ctrl-/ (Cmd-/ on macOS):toggleComment
- Shift-Alt-a: toggleBlockComment

However the cmd-/ doens't work on swedish keyboard layouts.. 