### PR TITLE
add none theme

### DIFF
--- a/demos/demo-base-react/src/Database.js
+++ b/demos/demo-base-react/src/Database.js
@@ -593,6 +593,11 @@ const Database = ({ CypherEditor, codemirrorVersion, framework, bundler }) => {
     setTheme("dark");
   };
 
+  const setThemeNone = () => {
+    addCommandLog("setTheme", "none");
+    setTheme("none");
+  };
+
   const setThemeAuto = () => {
     addCommandLog("setTheme", "auto");
     setTheme("auto");
@@ -1273,6 +1278,12 @@ const Database = ({ CypherEditor, codemirrorVersion, framework, bundler }) => {
               onClick={setThemeDark}
             >
               Dark
+            </button>
+            <button
+              className={theme === "none" ? "setting-active" : undefined}
+              onClick={setThemeNone}
+            >
+              None
             </button>
             <button
               className={theme === "auto" ? "setting-active" : undefined}

--- a/demos/demo-base-svelte/src/Database.svelte
+++ b/demos/demo-base-svelte/src/Database.svelte
@@ -847,6 +847,10 @@
           on:click={() => (theme = "dark")}>Dark</button
         >
         <button
+          class={theme === "none" ? "setting-active" : undefined}
+          on:click={() => (theme = "none")}>None</button
+        >
+        <button
           class={theme === "auto" ? "setting-active" : undefined}
           on:click={() => (theme = "auto")}>Auto</button
         >

--- a/packages/codemirror/css/cypher-codemirror.css
+++ b/packages/codemirror/css/cypher-codemirror.css
@@ -337,6 +337,36 @@ green     #859900  2/2 green     64 #5f8700 60 -20  65 133 153   0  68 100  60
 }
 
 /***********
+ * No theme
+ */
+.cm-editor.cm-cypher.cm-none .cm-comment,
+.cm-editor.cm-cypher.cm-none .cm-string,
+.cm-editor.cm-cypher.cm-none .cm-number,
+.cm-editor.cm-cypher.cm-none .cm-keyword,
+.cm-editor.cm-cypher.cm-none .cm-label,
+.cm-editor.cm-cypher.cm-none .cm-p-relationshipType,
+.cm-editor.cm-cypher.cm-none .cm-p-relationshipType .cm-keyword 
+.cm-editor.cm-cypher.cm-none .cm-p-variable,
+.cm-editor.cm-cypher.cm-none .cm-p-variable .cm-variable,
+.cm-editor.cm-cypher.cm-none .cm-p-variable .cm-keyword,
+.cm-editor.cm-cypher.cm-none .cm-p-procedure,
+.cm-editor.cm-cypher.cm-none .cm-p-procedure .cm-keyword,
+.cm-editor.cm-cypher.cm-none .cm-p-function,
+.cm-editor.cm-cypher.cm-none .cm-p-function .cm-keyword ,
+.cm-editor.cm-cypher.cm-none .cm-p-parameter,
+.cm-editor.cm-cypher.cm-none .cm-p-parameter .cm-keyword ,
+.cm-editor.cm-cypher.cm-none .cm-p-property,
+.cm-editor.cm-cypher.cm-none .cm-p-property .cm-keyword ,
+.cm-editor.cm-cypher.cm-none .cm-p-consoleCommand,
+.cm-editor.cm-cypher.cm-none .cm-p-consoleCommand .cm-keyword ,
+.cm-editor.cm-cypher.cm-none .cm-p-procedureOutput,
+.cm-editor.cm-cypher.cm-none .cm-p-procedureOutput .cm-keyword ,
+.cm-editor.cm-cypher.cm-none .cm-operator {
+    color: #888888;
+}
+
+
+/***********
  * Parser
  */
 

--- a/packages/codemirror/src/codemirror.d.ts
+++ b/packages/codemirror/src/codemirror.d.ts
@@ -59,7 +59,7 @@ export type PositionAny = PositionObject | PartialPositionObject | number;
 /**
  * The current editor theme
  */
-export type Theme = "light" | "dark" | "auto";
+export type Theme = "light" | "dark" | "auto" | "none";
 
 /**
  * The prop keys that can be used with autofocusProps

--- a/packages/codemirror/src/cypher-codemirror-base.js
+++ b/packages/codemirror/src/cypher-codemirror-base.js
@@ -1,5 +1,6 @@
 export const THEME_LIGHT = "light";
 export const THEME_DARK = "dark";
+export const THEME_NONE = "none";
 export const THEME_AUTO = "auto";
 
 export const defaultLineNumberFormatter = (line, lineCount) => {

--- a/packages/codemirror/src/cypher-extensions.js
+++ b/packages/codemirror/src/cypher-extensions.js
@@ -38,7 +38,12 @@ import {
 import { tags } from "@lezer/highlight";
 import { TreeUtils } from "@neo4j-cypher/editor-support";
 
-import { THEME_DARK, THEME_AUTO } from "./cypher-codemirror-base";
+import {
+  THEME_LIGHT,
+  THEME_DARK,
+  THEME_AUTO,
+  THEME_NONE
+} from "./cypher-codemirror-base";
 import { cypher } from "./cypher";
 import {
   typeMarkerField,
@@ -258,6 +263,11 @@ const themeLightExtensions = [
   EditorView.editorAttributes.of({ class: "cm-light" })
 ];
 
+const themeNone = [
+  EditorView.theme(themeOverrides, {}),
+  EditorView.editorAttributes.of({ class: "cm-none" })
+];
+
 const themeAutoExtensions = [
   EditorView.theme(themeOverrides, {}),
   EditorView.editorAttributes.of({ class: "cm-auto" })
@@ -413,11 +423,12 @@ export const getTabKeyExtensions = ({ tabKey, indentUnit }) =>
   tabKey ? tabKeyExtensions.concat(indentUnitExtension.of(indentUnit)) : [];
 
 export const getThemeExtensions = ({ theme }) =>
-  theme === THEME_DARK
-    ? themeDarkExtensions
-    : theme === THEME_AUTO
-    ? themeAutoExtensions
-    : themeLightExtensions;
+  ({
+    [THEME_DARK]: themeDarkExtensions,
+    [THEME_LIGHT]: themeLightExtensions,
+    [THEME_AUTO]: themeAutoExtensions,
+    [THEME_NONE]: themeNone
+  }[theme] ?? themeLightExtensions);
 
 export const getSearchExtensions = ({ readOnly, search, searchTop }) =>
   search ? (searchTop ? searchTopExtensions : searchBottomExtensions) : [];


### PR DESCRIPTION
In browser/query we have multiple editors mounted, but only want to show one as active - leaving the others grayed out. I ran into performance and stability issues when I rapidly turned all of cypher support on and off, so I figured a "no-highlighting" theme could be a better solution. Thoughts?